### PR TITLE
feat(): enable auto-merge on bump PRs

### DIFF
--- a/.github/workflows/build-layer.yml
+++ b/.github/workflows/build-layer.yml
@@ -92,6 +92,20 @@ jobs:
           retention-days: 1
 
   ################################
+  #### GATE
+  all-builds-passed:
+    name: All builds passed
+    needs: [package-duckdb]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check matrix result
+        run: |
+          if [ "${{ needs.package-duckdb.result }}" != "success" ]; then
+            exit 1
+          fi
+
+  ################################
   #### PUBLISH LAYERS
   publish-layer:
     name: Publish Layer to all AWS Regions

--- a/.github/workflows/bump-duckdb.yml
+++ b/.github/workflows/bump-duckdb.yml
@@ -63,6 +63,7 @@ jobs:
         run: echo "${{ steps.pypi.outputs.version }}" > .github/.duckdb-version
 
       - name: Create pull request
+        id: create-pr
         if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
@@ -80,3 +81,9 @@ jobs:
             > [!NOTE]
             > If `PYTHON_VERSIONS` needs updating (new Lambda runtime or DuckDB dropped/added support), edit `.github/workflows/build-layer.yml` directly on this branch before merging.
           labels: dependencies
+
+      - name: Enable auto-merge
+        if: steps.diff.outputs.changed == 'true' && steps.create-pr.outputs.pull-request-operation == 'created'
+        run: gh pr merge --auto --squash "${{ steps.create-pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Follows up on #25.

Once the build matrix passes on a bump PR, auto-merge triggers automatically, no need to merge manually.

## How it works
After `peter-evans/create-pull-request` opens a new `bump/duckdb-X.Y.Z` PR, the workflow calls `gh pr merge --auto --merge` on it. The merge happens only when all required status checks pass. If any job fails (e.g. a Python version no longer supported by DuckDB), the PR stays open for review.

## Setup required
In addition to the setup described in #25:
1. Settings > General > enable **Allow auto-merge**
2. Branch protection on `main`: configure `Build DuckDB` (the `package-duckdb` matrix jobs) as required status checks

## Open question
Auto-merge is intentionally gated on the build matrix only. **However, until `PYTHON_VERSIONS` is managed automatically** (detecting which Python versions DuckDB ships wheels for and which Lambda supports), **a passing build does not guarantee complete coverage**, it only validates the versions currently in the matrix.

**My approach would be to: keep "Require approvals" enabled** on `main` so a reviewer can check `PYTHON_VERSIONS` before merging. Auto-merge would still remove the need to click merge manually, but would wait for the approval first. **Or check Python versions in the CI #29.**